### PR TITLE
Fixes typo in Provider(s) namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features:
 
 ```php
 # Get an instance of the ArrayProvider
-$provider = new \werx\Config\Provider\ArrayProvider('/path/to/config/directory');
+$provider = new \werx\Config\Providers\ArrayProvider('/path/to/config/directory');
 
 # Create a Config\Container Instance from this provider.
 $config = new \werx\Config\Container($provider);


### PR DESCRIPTION
I was just playing around with this lib and noticed the typo in the docs.
