### PR TITLE
Reference configs and walk arrays

### DIFF
--- a/tests/ContainerTests.php
+++ b/tests/ContainerTests.php
@@ -86,4 +86,17 @@ class ConfigTests extends \PHPUnit_Framework_TestCase
 		$this->assertEquals(false, $this->config->extra('doesnotexist', false), 'Should return default: false.');
 		$this->assertArrayHasKey('foo', $this->config->extra(), 'Should return all items from the extra index.');
 	}
+
+	public function testCanWalkContainer()
+	{
+		$this->config->load('walk', true);
+		$this->assertEquals('dead', $this->config->walk('walkers:are','not dead'));
+		$this->assertEquals('default', $this->config->walk('default'));
+		$this->assertTrue($this->config->walk('missing', true));
+		$this->assertEquals(['name'=>'default'], $this->config->walk('alias'));
+		$this->assertEquals("default", $this->config->walk('alias:name'));
+		$this->assertEquals("could", $this->config->walk("not:that:you:would:but:you"));
+		$this->assertNull($this->config->walk("not:that:you:would:but:you:could"));
+		$this->assertEquals("forgot 'you'", $this->config->walk("not:that:would:but:you:could", "forgot 'you'"));
+	}
 }

--- a/tests/resources/config_array/walk.php
+++ b/tests/resources/config_array/walk.php
@@ -1,0 +1,20 @@
+<?php 
+return [
+	"default" => "#default:name",
+	"missing" => "#default:test",
+	"alias" => "#default",
+	"walkers" => [
+		"are" => "dead"
+	],
+	"not" => [
+		"that" => [
+			"you" => [
+				"would" => [
+					"but" => [
+						"you" => "could"
+					]
+				]
+			]
+		]
+	]
+];


### PR DESCRIPTION
## Added ability to reference configs from config items by prefixing with '#'

### logging.php
```php
return ['dsn' => '#database:default'];
```
### database.php
```php
return ['default' => '<db connection info>'];

### code
```php
$config->load('logging');
$config->get('dsn'); // returns '<db connection info>';
```

## Added ability to walk configuration items.
```php
return ['db' => ['host' => ['host_name' => 'localhost', 'port' => 4000] ] ] ;
```

```php
$config->get('db:host:port', 3308); // returns 4000 
$config->get('db:host:portnum', 3308); //returns 3308 ('portnum' not found, so uses default)
```
