### PR TITLE
add callable support for building items inside configs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
 			"werx\\Config\\": "src/",
 			"werx\\Config\\Providers\\": "src/Providers"
 		}
+	}, 
+	"autoload-dev":	{
+		"psr-4": {
+			"werx\\Config\\Tests\\": "Tests/"
+		}
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 
     <testsuites>
         <testsuite name="LibraryTests">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Tests.php">./tests/</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -23,7 +23,6 @@ class Container
 		if (empty($provider)) {
 			$provider = new Providers\ArrayProvider();
 		}
-
 		$this->provider = $provider;
 	}
 
@@ -85,9 +84,9 @@ class Container
 	public function get($key, $default_value = null, $index_name = 'default')
 	{
 		if (array_key_exists($index_name, $this->items)) {
-			return $this->walkConfig($this->items[$index_name], $key, $default_value);
+			return $this->evaluate($this->walkConfig($this->items[$index_name], $key, $default_value));
 		} else {
-			return $default_value;
+			return $this->evaluate($default_value);
 		}
 	}
 
@@ -102,7 +101,7 @@ class Container
 			$data = $result[$k];
 			if (is_string($data) && substr($data, 0, 1) === "#") {
 				if (strpos($data, ":") > 0) {
-					$group = strstr(substr($data,1),":", true);	
+					$group = strstr(substr($data,1),":", true);
 					$this->load($group, true, false);
 					$data = $this->$group( substr(strstr($data,":"),1), $default_value);
 				} else {
@@ -150,5 +149,11 @@ class Container
 		if (array_key_exists($method, $this->items)) {
 			return $this->get($item, $default, $method);
 		}
+	}
+
+	private function evaluate($value)
+	{
+		$invokable = is_object($value) && method_exists($value,'__invoke') || is_callable($value);
+		return $invokable ? $value($this) : $value;
 	}
 }

--- a/src/Providers/ArrayProvider.php
+++ b/src/Providers/ArrayProvider.php
@@ -55,4 +55,16 @@ class ArrayProvider implements ProviderInterface
 			return $this->path . DIRECTORY_SEPARATOR . basename($file, '.php') . '.php';
 		}
 	}
+
+	protected function singleton(callable $factory)
+	{
+		$singleton_factory = function ($container) use($factory) {
+			static $instance;
+			if ($instance === null) {
+				$instance = $factory($container);
+			}
+			return $instance;
+		};
+		return $singleton_factory;
+	}
 }

--- a/src/Providers/ProviderInterface.php
+++ b/src/Providers/ProviderInterface.php
@@ -2,11 +2,13 @@
 
 namespace werx\Config\Providers;
 
+use \werx\Config\Container;
+
 interface ProviderInterface
 {
 	/**
-	 * @string $group
-	 * @string null $environment
+	 * @param string $group
+	 * @param string|null $environment
 	 */
 	public function load($group, $environment = null);
 }

--- a/tests/ContainerTests.php
+++ b/tests/ContainerTests.php
@@ -99,4 +99,31 @@ class ConfigTests extends \PHPUnit_Framework_TestCase
 		$this->assertNull($this->config->walk("not:that:you:would:but:you:could"));
 		$this->assertEquals("forgot 'you'", $this->config->walk("not:that:would:but:you:could", "forgot 'you'"));
 	}
+
+	public function testCanUseCallable()
+	{
+		$this->config->load('callable');
+		$this->assertEquals('default', $this->config->get('foo'));
+	}
+
+	public function testCanUseCallableDefault()
+	{
+		$this->config->load('callable');
+		$this->assertEquals('default', $this->config->get('doesnotexist', function() { return "default"; }));
+	}
+
+	public function testCanUseCallableSingleton()
+	{
+		$this->config->load('callable');
+		$bar = $this->config->get('bar');
+		$this->assertTrue($bar === $this->config->get('bar'));
+	}
+
+	public function testCanUseCallableNotSingleton()
+	{
+		$this->config->load('callable');
+		$bar = $this->config->get('bar2');
+		$this->assertTrue($bar !== $this->config->get('bar2'));
+	}
+
 }

--- a/tests/resources/config_array/callable.php
+++ b/tests/resources/config_array/callable.php
@@ -1,0 +1,14 @@
+<?php 
+
+return [
+	"foo" => function(\werx\Config\Container $container) {
+		$container->load('default');
+		return $container->get('name');
+	},
+	"bar" => $this->singleton( function($container) {
+		return (object)['test' => true];
+	}),
+	"bar2" => function($container) {
+		return (object)['test' => true];
+	}
+];


### PR DESCRIPTION
See tests for a (contrived) example of how this is used. This would be useful for configuring items that may need outside configuration. It is arguable that this is outside of the realm of a config, but still pretty handy I think.